### PR TITLE
Adds new convenience methods

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -37,10 +37,10 @@ class Config
             $class = self::class;
             throw new UndefinedConfigKeyException("'$key' has not been defined. Use `$class::define('$key', ...)`.");
         }
-        
+
         return self::$configMap[$key];
     }
-    
+
     /**
      * @param string $key
      */
@@ -93,7 +93,7 @@ class Config
             defined($key) or define($key, $value);
         }
     }
-    
+
     /**
      * @param string $key
      * @return bool
@@ -105,7 +105,59 @@ class Config
             $message = "Aborted trying to redefine constant '$key'. `define('$key', ...)` has already been occurred elsewhere.";
             throw new ConstantAlreadyDefinedException($message);
         }
-        
+
         return false;
+    }
+
+    /**
+     * Define set of config items.
+     *
+     * @param array definitions
+     * @return void
+     */
+    protected static function defineSet($definitions)
+    {
+        foreach ($definitions as $const => $def) {
+            self::define($const, $def);
+        }
+    }
+
+    /**
+     * Checks a value in the config map.
+     *
+     * @param string config key
+     * @return bool
+     */
+    protected static function is($key, $definition)
+    {
+        return self::$configMap[$key] == $definition;
+    }
+
+    /**
+     * Checks a key against the config map.
+     *
+     * @param string config key
+     * @return bool
+     */
+    protected static function containsKey($definition)
+    {
+        return array_key_exists($definition, self::$configMap);
+    }
+
+    /**
+     * Checks an array of keys against the config map.
+     *
+     * @param array config keys
+     * @return bool
+     */
+    protected static function containsKeys(array $definitions)
+    {
+        foreach ($definitions as $definition) {
+            if (! self::containsKey($definition)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -115,7 +115,7 @@ class Config
      *
      * @param iterable key-value array of definitions
      */
-    protected static function defineMap(iterable $definitions): void
+    public static function defineMap(iterable $definitions): void
     {
         foreach ($definitions as $const => $def) {
             self::define($const, $def);
@@ -128,7 +128,7 @@ class Config
      * @param string config key
      * @return bool
      */
-    protected static function containsKey(string $definition): bool
+    public static function containsKey(string $definition): bool
     {
         return array_key_exists($definition, self::$configMap);
     }
@@ -139,7 +139,7 @@ class Config
      * @param iterable config keys
      * @return bool
      */
-    protected static function containsKeys(iterable $definitions): bool
+    public static function containsKeys(iterable $definitions): bool
     {
         foreach ($definitions as $definition) {
             if (! self::containsKey($definition)) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -21,7 +21,7 @@ class Config
      * @param $value
      * @throws ConstantAlreadyDefinedException
      */
-    public static function define($key, $value)
+    public static function define(string $key, $value)
     {
         self::defined($key) or self::$configMap[$key] = $value;
     }
@@ -31,7 +31,7 @@ class Config
      * @return mixed
      * @throws UndefinedConfigKeyException
      */
-    public static function get($key)
+    public static function get(string $key)
     {
         if (!array_key_exists($key, self::$configMap)) {
             $class = self::class;
@@ -44,7 +44,7 @@ class Config
     /**
      * @param string $key
      */
-    public static function remove($key)
+    public static function remove(string $key)
     {
         unset(self::$configMap[$key]);
     }
@@ -99,7 +99,7 @@ class Config
      * @return bool
      * @throws ConstantAlreadyDefinedException
      */
-    protected static function defined($key)
+    protected static function defined(string $key)
     {
         if (defined($key)) {
             $message = "Aborted trying to redefine constant '$key'. `define('$key', ...)` has already been occurred elsewhere.";
@@ -110,27 +110,15 @@ class Config
     }
 
     /**
-     * Define set of config items.
+     * Define map of config items.
      *
-     * @param array definitions
-     * @return void
+     * @param iterable key-value array of definitions
      */
-    protected static function defineSet($definitions)
+    protected static function defineMap(iterable $definitions)
     {
         foreach ($definitions as $const => $def) {
             self::define($const, $def);
         }
-    }
-
-    /**
-     * Checks a value in the config map.
-     *
-     * @param string config key
-     * @return bool
-     */
-    protected static function is($key, $definition)
-    {
-        return self::$configMap[$key] == $definition;
     }
 
     /**
@@ -139,7 +127,7 @@ class Config
      * @param string config key
      * @return bool
      */
-    protected static function containsKey($definition)
+    protected static function containsKey(string $definition)
     {
         return array_key_exists($definition, self::$configMap);
     }
@@ -147,10 +135,10 @@ class Config
     /**
      * Checks an array of keys against the config map.
      *
-     * @param array config keys
+     * @param iterable config keys
      * @return bool
      */
-    protected static function containsKeys(array $definitions)
+    protected static function containsKeys(iterable $definitions)
     {
         foreach ($definitions as $definition) {
             if (! self::containsKey($definition)) {


### PR DESCRIPTION
In my Bedrock projects I typically extend the `Config` class with some simple static methods which I have found to have broad utility. It is the aim of this PR to have them integrated into the core `Config` class. 

I think that they are a good fit for inclusion here as they promote readability while also not over-complicating or obscuring implementation details (a central tenant of the Bedrock project.) 

Further I am happy to submit a PR to the Bedrock repo taking advantage of the features included here, should there be interest. Or, it could just be left to be adopted incrementally.

Note that I have not updated the test suite. Personally I think adding `@covers` annotations to the existing methods would be sufficient, since the new methods are simply wrapping existing methods.

**Examples of the syntax this PR enables**

```php
/**
 * Configure auth keys and salts.
 */
Config::defineSet([
    'AUTH_KEY' => env('AUTH_KEY'),
    'AUTH_SALT' => env('AUTH_SALT'),
    'LOGGED_IN_KEY' => env('LOGGED_IN_KEY'),
    'LOGGED_IN_SALT' => env('LOGGED_IN_SALT'),
    'NONCE_KEY' => env('NONCE_KEY'),
    'NONCE_SALT' => env('NONCE_SALT'),
    'SECURE_AUTH_KEY' => env('SECURE_AUTH_KEY'),
    'SECURE_AUTH_SALT' => env('SECURE_AUTH_SALT'),
]);
```

```php
if (Config::containsKey('DISPLAY_ERRORS')) {
    ini_set('display_errors', Config::get('DISPLAY_ERRORS'));
}
```

```php
if (Config::containsKeys(['SENTRY_DSN', 'WP_ENV']) &&
    ! Config::is('WP_ENV', 'development')) {
    \Sentry\init([
        'dsn'         => Config::get('SENTRY_DSN'),
        'environment' => Config::get('WP_ENV'),
        'release'     => Config::get('GIT_SHA'),
        'error_types' => E_ALL & ~E_NOTICE & ~E_DEPRECATED,
    ]);
}
```