### PR TITLE
Bump minimum PHP requirement from 5.6 to 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 php:
+- '7.4'
+- '7.3'
 - '7.2'
 - '7.1'
-- '7.0'
-- '5.6'
 - nightly
 
 install: make travis-install

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ install: make travis-install
 script: make travis-test
 
 jobs:
+  allow_failures:
+  - php: nightly
   include:
   - stage: "Follow Up"
     name: "Test Coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ jobs:
   include:
   - stage: "Follow Up"
     name: "Test Coverage"
+    php: '7.1'
     script: travis_retry make travis-coverage
   - name: "Code Style"
+    php: '7.1'
     script: make travis-phpcs

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ vendor: composer.lock
 	${MAKE} install
 
 test: vendor
-	${DRUN} php:5.6 ${PHPUNIT}
-	${DRUN} php:7.0 ${PHPUNIT}
 	${DRUN} php:7.1 ${PHPUNIT}
 	${DRUN} php:7.2 ${PHPUNIT}
+	${DRUN} php:7.3 ${PHPUNIT}
+	${DRUN} php:7.4 ${PHPUNIT}
 	${DRUN} php:7 ${PHPUNIT}
 
 test-fast: vendor

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ echo WP_DEBUG_DISPLAY;
 
 Just run `make` to do everything
 
-We use PHPUnit 5 because it has compatibility for PHP 5.6
+We use PHPUnit 7 because it has compatibility for PHP 7.1
 
-[PHPUnit Docs](https://phpunit.de/manual/5.7/en/index.html)
+[PHPUnit Docs](https://phpunit.readthedocs.io/en/7.5/)
 
 There are 3 test commands
 
-- `make test` run the full test suite from php 5.6 to 7.x
+- `make test` run the full test suite from php to 7.1 to 7.4
 - `make test-fast` run php 7 tests
 - `make test-coverage` generate an html test coverage report in `./coverage`

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,5 @@
     "roave/security-advisories": "dev-master",
     "phpunit/phpunit": "^7.5",
     "php-coveralls/php-coveralls": "^2.2"
-  },
-  "config": {
-    "platform": {
-      "php": "7.1"
-    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,17 @@
     }
   },
   "require": {
-    "php": ">=5.6"
+    "php": "^7.1"
   },
   "require-dev": {
-    "squizlabs/php_codesniffer": "^3.3",
+    "squizlabs/php_codesniffer": "^3.5",
     "roave/security-advisories": "dev-master",
-    "phpunit/phpunit": "^5.7",
-    "php-coveralls/php-coveralls": "^2.1"
+    "phpunit/phpunit": "^7.5",
+    "php-coveralls/php-coveralls": "^2.2"
   },
   "config": {
     "platform": {
-      "php": "5.6"
+      "php": "7.1"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   },
   "require": {
-    "php": "^7.1"
+    "php": ">=7.1"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.5",

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -2,13 +2,14 @@
 
 namespace Roots\WPConfig;
 
+use PHPUnit\Framework\TestCase;
 use Roots\WPConfig\Exceptions\ConstantAlreadyDefinedException;
 use Roots\WPConfig\Exceptions\UndefinedConfigKeyException;
 
 /**
  * @runTestsInSeparateProcesses
  */
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends TestCase
 {
   
   public function testDefineHappy() {


### PR DESCRIPTION
- Bump minimum PHP requirement from 5.6 to 7.1 (inline with [Bedrock](https://github.com/roots/bedrock/blob/ff5e28ac74f1e9aac1b44f8d197054a34eb85079/composer.json#L33))
- Add PHP 7.3 and 7.4 to test matrix
- Update dependencies

See: https://github.com/roots/wp-config/issues/4