### PR TITLE
Disallow numeric constant name

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Roots\WPConfig;
 
 use Roots\WPConfig\Exceptions\ConstantAlreadyDefinedException;
+use Roots\WPConfig\Exceptions\NumericConstantNameException;
 use Roots\WPConfig\Exceptions\UndefinedConfigKeyException;
 
 /**
@@ -24,6 +25,10 @@ class Config
      */
     public static function define(string $key, $value): void
     {
+        if (is_numeric($key)) {
+            throw new NumericConstantNameException("Numeric constant name '$key' is not allowed.");
+        }
+
         self::defined($key) or self::$configMap[$key] = $value;
     }
 

--- a/src/Exceptions/NumericConstantNameException.php
+++ b/src/Exceptions/NumericConstantNameException.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Roots\WPConfig\Exceptions;
+
+class NumericConstantNameException extends \RuntimeException
+{
+
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -5,6 +5,7 @@ namespace Roots\WPConfig;
 
 use PHPUnit\Framework\TestCase;
 use Roots\WPConfig\Exceptions\ConstantAlreadyDefinedException;
+use Roots\WPConfig\Exceptions\NumericConstantNameException;
 use Roots\WPConfig\Exceptions\UndefinedConfigKeyException;
 
 /**
@@ -16,6 +17,12 @@ class ConfigTest extends TestCase
   public function testDefineHappy() {
     Config::define('WP_SCRIPT_DEBUG', true);
     $this->assertEquals(true, Config::get('WP_SCRIPT_DEBUG'));
+  }
+
+  public function testDefineSadIntegerKey() {
+      $this->expectException(NumericConstantNameException::class);
+
+      Config::define('123', true);
   }
   
   public function testDefineSad() {


### PR DESCRIPTION
close #4

Note: There are a few more constant names will break, e.g: `null`, `true`, `false`.
Haven't think of a good way to catch them all.