### PR TITLE
Makefile: DRY up testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default clean install update init phpcs phpcbf
+.PHONY: default clean init phpcs phpcbf
 .PHONY: travis-install travis-test travis-coverage travis-phpcs
 
 DRUN=docker run --rm -v $(shell pwd):/app -w /app
@@ -12,10 +12,10 @@ PHPCS=vendor/bin/phpcs src
 default: vendor test
 
 composer.lock: composer.json
-	${MAKE} update
+	${COMPOSER} update ${COMPOSER_FLAGS}
 
 vendor: composer.lock
-	${MAKE} install
+	${COMPOSER} install ${COMPOSER_FLAGS}
 
 .PHONY: test-% test test-fast test-coverage
 test-%: vendor
@@ -31,12 +31,6 @@ test-coverage: vendor
 
 clean:
 	${RUN} rm -rf vendor composer.lock
-
-install:
-	${COMPOSER} install ${COMPOSER_FLAGS}
-
-update:
-	${COMPOSER} update ${COMPOSER_FLAGS}
 
 init: clean vendor
 

--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,10 @@ composer.lock: composer.json
 vendor: composer.lock
 	${MAKE} install
 
-test: vendor
-	${DRUN} php:7.1 ${PHPUNIT}
-	${DRUN} php:7.2 ${PHPUNIT}
-	${DRUN} php:7.3 ${PHPUNIT}
-	${DRUN} php:7.4 ${PHPUNIT}
-	${DRUN} php:7 ${PHPUNIT}
+test-%: vendor
+	${DRUN} php:$(@:test-%=%) ${PHPUNIT}
+
+test: test-7.1 test-7.2 test-7.3 test-7.4
 
 test-fast: vendor
 	${DRUN} php:7 ${PHPUNIT}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default test test-fast test-coverage clean install update init phpcs phpcbf
+.PHONY: default clean install update init phpcs phpcbf
 .PHONY: travis-install travis-test travis-coverage travis-phpcs
 
 DRUN=docker run --rm -v $(shell pwd):/app -w /app
@@ -17,6 +17,7 @@ composer.lock: composer.json
 vendor: composer.lock
 	${MAKE} install
 
+.PHONY: test-% test test-fast test-coverage
 test-%: vendor
 	${DRUN} php:$(@:test-%=%) ${PHPUNIT}
 


### PR DESCRIPTION
The following graph is what is needed to run `make test`

![dag](https://user-images.githubusercontent.com/2192970/76637663-28201380-6519-11ea-9591-d4f431fd8df0.png)

@TangRufus here's an example of some makefile best practices. Notice how we can now use `make -j` to run test-* all in parallel.