### PR TITLE
Make `$ make test` works again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,10 @@
     "branch-alias": {
         "dev-master": "2.0.x-dev"
     }
+  },
+  "config": {
+    "platform": {
+      "php": "7.1.0"
+    }
   }
 }


### PR DESCRIPTION
Make `$ make test` works again.
To be replaced with [composer scripts](https://getcomposer.org/doc/04-schema.md#scripts) in future PRs.