### PR TITLE
GitHub Actions: Add `pint` workflow

### DIFF
--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.4'
           tools: pint:1
           coverage: none
         env:

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -1,0 +1,34 @@
+name: Pint
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  pint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: pint:1
+          coverage: none
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: composer lint


### PR DESCRIPTION
This workflow checks `$ composer lint` on `master` push & PRs to `master`.

Note that pint v1.x.x is used instead of the one specificed in `composer.json`. This is because version conflict with phpunit.

Example run: https://github.com/tangrufus/wp-config/actions/runs/13322893284/job/37210603386?pr=1

---

Discussion: I am inclined towards:
1. remove pint from composer.json
2. remove `$ pint --test` requirement from PRs (we dont have this yet)
3. run `$ pint` on `master` pushes
4. create PRs if `$ pint` fixed any files
5. auto merge those PRs into `master`

Examples:
- https://github.com/typisttech/php-matrix/blob/05a7f203925d0a5a7e7edff11863bbf69f496e05/.github/workflows/pint.yml
- https://github.com/typisttech/.github/blob/cde0202800be57935b4dfbbf17cc47ea85c9787f/.github/workflows/pint.yml
- https://laravel.com/docs/11.x/pint#running-tests-on-github-actions