### PR TITLE
GitHub Actions: Add `test` workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,76 @@
+name: Test
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+      - v2 # Temporary until v2 is merged into master
+  push:
+    branches:
+      - master
+      - v2 # Temporary until v2 is merged into master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        php: ['8.1', '8.2', '8.3', '8.4']
+        dependency-versions: [lowest, highest]
+        coverage: [none]
+        exclude:
+          - php: '8.4'
+            dependency-versions: highest
+            coverage: none
+        include:
+          - php: '8.4'
+            dependency-versions: highest
+            coverage: xdebug
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: ${{ matrix.coverage }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ramsey/composer-install@v3
+        with:
+          dependency-versions: ${{ matrix.dependency-versions }}
+          composer-options: --no-audit --optimize-autoloader
+
+      - run: composer test -- --coverage-clover coverage.xml
+        if: ${{ matrix.coverage == 'xdebug' }}
+
+      - run: composer test -- --no-coverage
+        if: ${{ matrix.coverage != 'xdebug' }}
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ matrix.coverage == 'xdebug' }}
+        with:
+          name: coverage
+          path: coverage.xml
+
+  coveralls:
+    needs: phpunit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage
+      - uses: coverallsapp/github-action@v2
+        with:
+          file: coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /vendor/
 /coverage/
 /composer.lock
+
+# PHPUnit
+/.phpunit.cache
+/coverage.xml

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     "vlucas/phpdotenv": "^5.6"
   },
   "require-dev": {
-    "phpunit/phpunit": "^10.0",
-    "laravel/pint": "^1.13"
+    "laravel/pint": "^1.13",
+    "phpunit/phpunit": "^10.5"
   },
   "scripts": {
     "test": "phpunit",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         backupGlobals="false"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
     <testsuites>
         <testsuite name="Config">
             <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <source>
+        <include>
             <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
1. Git ignore `/.phpunit.cache` & `/coverage.xml`
2. `composer require --dev phpunit/phpunit:^10.5`
3. `./vendor/bin/phpunit --migrate-configuration`
4.  GitHub Actions: Add `test` workflow

Example workflow run: https://github.com/tangrufus/wp-config/actions/runs/13475857186
Example coverage report: https://coveralls.io/jobs/160825043

---

PHP versions are hardcoded in the workflow. 

If we want to be lazy, we could use https://github.com/typisttech/php-matrix-action
Example: https://github.com/typisttech/wordfence-api/blob/68a230833b5c1a9aca5e46bfa595bef1304435d5/.github/workflows/test.yml#L19-L39
