### PR TITLE
Fixed reading env file

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -94,10 +94,12 @@ class Config
             return $this->envMany($key, $default);
         }
 
-        $value = match (true) {
-            function_exists('env') => env($key, $default),
-            default => getenv($key) ?? $_ENV[$key] ?? $default,
-        };
+	    $value = match (true) {
+	        function_exists('env') => env($key, $default),
+	        getenv($key) !== false => getenv($key),
+	        isset($_ENV[$key]) => $_ENV[$key],
+	        default => $default,
+	    };
 
         $this->set($key, $value);
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -96,7 +96,6 @@ class Config
 
         $value = match (true) {
             function_exists('env') => env($key, $default),
-            function_exists('\Env\env') => \Env\env($key, $default),
             default => getenv($key) ?? $_ENV[$key] ?? $default,
         };
 


### PR DESCRIPTION
This PR aims to fix an issue with the V2 configuration file, which prevents the correct use of the $config->env() method.

The expected behavior should be:
1. Check if a value in a .env file exists and use that value.
2. If the value doesn't exist in an env file, set $config->set() with the default value sent.

Todo: Don't forget to modify the documentation