### PR TITLE
✨ Add WordPress-style hook system

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ $config
 - 🔄 Fluent API for clean, chainable configuration
 - 🌍 Built-in environment variable loading
 - 🔀 Conditional configuration with `when()`
+- 🪝 WordPress-style hook system for extensible configuration
 - 📦 Zero dependencies (except `vlucas/phpdotenv`)
 
 ## Requirements
@@ -79,6 +80,24 @@ $config->bootstrapEnv(); // Loads .env and .env.local files
 $config
     ->set('DB_NAME', env('DB_NAME'))
     ->set('DB_USER', env('DB_USER'))
+    ->apply();
+```
+
+### Hook system
+
+The Config class includes a WordPress-style hook system for extensible configuration:
+
+```php
+// Register a hook
+Config::add_action('security_setup', function($config) {
+    $config->set('FORCE_SSL_ADMIN', true);
+    $config->set('DISALLOW_FILE_EDIT', true);
+});
+
+// Execute the hook
+$config
+    ->set('WP_ENV', 'production')
+    ->do_action('security_setup')
     ->apply();
 ```
 
@@ -177,6 +196,12 @@ Conditionally executes configuration logic.
 
 #### `apply(): void`
 Applies all configuration values by defining constants.
+
+#### `add_action(string $tag, callable $callback, int $priority = 10): void`
+Adds a hook callback that can be executed later with `do_action()`. Static method.
+
+#### `do_action(string $tag, ...$args): self`
+Executes all callbacks registered for the specified hook. Returns `$this` for chaining.
 
 ### Exceptions
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -23,6 +23,11 @@ class Config
      */
     protected string $rootDir;
 
+    /**
+     * @var array<string, array<int, array{callback: callable, priority: int}>>
+     */
+    protected static array $hooks = [];
+
     public function __construct(string $rootDir)
     {
         $this->rootDir = $rootDir;
@@ -136,6 +141,51 @@ class Config
 
         if ($result) {
             $callback($this);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an action hook
+     *
+     * @param string $tag The hook name
+     * @param callable $callback The callback function
+     * @param int $priority The priority (lower numbers = higher priority)
+     * @return void
+     */
+    public static function add_action(string $tag, callable $callback, int $priority = 10): void
+    {
+        if (!isset(static::$hooks[$tag])) {
+            static::$hooks[$tag] = [];
+        }
+
+        static::$hooks[$tag][] = [
+            'callback' => $callback,
+            'priority' => $priority,
+        ];
+    }
+
+    /**
+     * Execute actions for a hook
+     *
+     * @param string $tag The hook name
+     * @param mixed ...$args Additional arguments to pass to callbacks
+     * @return self
+     */
+    public function do_action(string $tag, ...$args): self
+    {
+        if (!isset(static::$hooks[$tag])) {
+            return $this;
+        }
+
+        // Sort hooks by priority (lower numbers = higher priority)
+        $hooks = static::$hooks[$tag];
+        usort($hooks, fn($a, $b) => $a['priority'] <=> $b['priority']);
+
+        // Execute hooks with $config as first parameter
+        foreach ($hooks as $hook) {
+            $hook['callback']($this, ...$args);
         }
 
         return $this;


### PR DESCRIPTION
This PR adds a WordPress-style hook system to the Config class

- `Config::add_action($tag, $callback, $priority)` - Register hook callbacks
- `$config->do_action($tag, ...$args)` - Execute registered hooks with fluent chaining
- Priority support for controlling execution order
- Hook callbacks receive the `$config` instance as first parameter

### Example: Simple Bedrock Addon

```php
// In a Bedrock addon package
Config::add_action('bedrock_defaults', function($config) {
    $config->set('WP_CONTENT_DIR', dirname(__DIR__) . '/web/app');
    $config->set('WP_CONTENT_URL', $config->get('WP_HOME') . '/app');
});

Ref #20